### PR TITLE
Hide 'impl_new_from_pseudo_default!(Box<T>, T)' under the std feature

### DIFF
--- a/src/implementations/pointers.rs
+++ b/src/implementations/pointers.rs
@@ -4,7 +4,10 @@ use core::{
     mem::ManuallyDrop,
 };
 
+// Box is only available with alloc.
+#[cfg(feature = "std")]
 impl_new_from_pseudo_default!(Box<T>, T);
+
 impl_new_from_pseudo_default!(UnsafeCell<T>, T);
 impl_new_from_pseudo_default!(RefCell<T>, T);
 impl_new_from_pseudo_default!(ManuallyDrop<T>, T);


### PR DESCRIPTION
The latest update is broken if the crate is compiled without default features (`default-features = false`). The easiest way to reproduce the issue is to compile one of the dependent crates, for example `orx-concurrent-vec`. I think it makes sense to yank the `1.5.0` version because this crate is usually an indirect dependency, so it is harder to pin it to a specific version.