### PR TITLE
fix/broken box impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pseudo-default"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "PseudoDefault trait allows to create a cheap default instance of a type, which does not claim to be useful."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pseudo-default"
-version = "1.6.0"
+version = "2.0.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "PseudoDefault trait allows to create a cheap default instance of a type, which does not claim to be useful."

--- a/src/implementations/pointers.rs
+++ b/src/implementations/pointers.rs
@@ -1,4 +1,5 @@
 use crate::impl_new_from_pseudo_default;
+use alloc::boxed::Box;
 use core::{
     cell::{RefCell, UnsafeCell},
     mem::ManuallyDrop,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@
 //!
 //! Similar to `Default`, it is possible to derive `PseudoDefault` provided that all members also implement `PseudoDefault`.
 //!
-//! ```rust
+//! ```rust ignore
 //! use orx_pseudo_default::*;
 //!
 //! #[derive(PseudoDefault)]

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -1,5 +1,6 @@
-extern crate alloc;
+#![cfg(feature = "derive")]
 
+extern crate alloc;
 use alloc::string::String;
 use orx_pseudo_default::*;
 


### PR DESCRIPTION
@Mr-Leshiy & @stanislav-tkach

Apologies for the break and thanks for the issue & PR.

@stanislav-tkach: I added the proper import `use alloc::boxed::Box;` instead.

The plan is as follows:

* We merge this PR and publish 2.0.0 of the orx-pseudo-default crate.
* And yank version 1.5.0.
* Consequently, the dependencies of the dependant crates will be upgraded to 2.0.0.

Please let me know if you have additional or different suggestions for the PR or plan for the fix. Otherwise, I'll quickly release them.

Fixes #11
 